### PR TITLE
Admin user create dummy password

### DIFF
--- a/resources/views/users/partials/create-user-form.blade.php
+++ b/resources/views/users/partials/create-user-form.blade.php
@@ -121,6 +121,12 @@
     <script>
         function generateHexPassword()
         {
+            // Check if crypto.getRandomValues is not supported by the user's browser. If not, leave passwords blank (will need to be filled manually)
+            if (!window.crypto || !window.crypto.getRandomValues) {
+                return "";
+            }
+
+            // Generate 8 cryptographically random bytes
             const byteArray = new Uint8Array(8); // 8 bytes = 64 bits = 16 hexadecimal characters
             window.crypto.getRandomValues(byteArray);
 

--- a/resources/views/users/partials/create-user-form.blade.php
+++ b/resources/views/users/partials/create-user-form.blade.php
@@ -71,6 +71,10 @@
             <x-form-validation for="password_confirmation" />
         </div>
 
+        <div>
+            <p>Use <a href="https://password.link/" style="color:blue">https://password.link/</a> to securely send passwords to users.</p>
+        </div>
+
         <!-- Primary Department ID -->
         <div>
             <x-input-label for="password" :value="__('Primary Department')" />

--- a/resources/views/users/partials/create-user-form.blade.php
+++ b/resources/views/users/partials/create-user-form.blade.php
@@ -57,7 +57,7 @@
                 <x-input-label for="password" :value="__('Password')" />
                 <x-required-asterisk/>
             </div>
-            <x-text-input id="password" name="password" type="password" placeholder="XXXXXXXX" class="mt-1 block w-full" required />
+            <x-text-input id="password" name="password" type="text" placeholder="XXXXXXXX" class="mt-1 block w-full" required />
             <x-form-validation for="password" />
         </div>
 
@@ -67,7 +67,7 @@
             <x-input-label for="password_confirmation" :value="__('Confirm Password')" />
                 <x-required-asterisk/>
             </div>
-            <x-text-input id="password_confirmation" type="password" placeholder="XXXXXXXX" name="password_confirmation" class="mt-1 block w-full" required />
+            <x-text-input id="password_confirmation" type="text" placeholder="XXXXXXXX" name="password_confirmation" class="mt-1 block w-full" required />
             <x-form-validation for="password_confirmation" />
         </div>
 
@@ -114,4 +114,22 @@
             @endif
         </div>
     </form>
+    <script>
+        function generateHexPassword()
+        {
+            const byteArray = new Uint8Array(8); // 8 bytes = 64 bits = 16 hexadecimal characters
+            window.crypto.getRandomValues(byteArray);
+
+            // Convert bytes to hexadecimal string
+            let hexString = '';
+            for (let i = 0; i < byteArray.length; i++) {
+                hexString += byteArray[i].toString(16).padStart(2, '0');
+            }
+
+            return hexString;
+        }
+        const generatedPass = generateHexPassword();
+        document.getElementById("password").value = generatedPass;
+        document.getElementById("password_confirmation").value = generatedPass;
+    </script>
 </section>

--- a/resources/views/users/partials/create-user-form.blade.php
+++ b/resources/views/users/partials/create-user-form.blade.php
@@ -24,6 +24,13 @@
             <x-form-validation for="email" />
         </div>
 
+        <!-- User Notes -->
+        <div>
+            <x-input-label for="notes" :value="__('User Notes')" />
+            <x-text-input id="notes" name="notes" type="text" class="mt-1 block w-full"/>
+            <x-form-validation for="notes" />
+        </div>
+
         <!-- User is Active -->
         <div>
             <x-input-label for="active" :value="__('Active Status')" />
@@ -44,12 +51,37 @@
             <x-form-validation for="admin" />
         </div>
 
-        <!-- User Notes -->
+        <hr>
+
+        <!-- Primary Sector ID -->
         <div>
-            <x-input-label for="notes" :value="__('User Notes')" />
-            <x-text-input id="notes" name="notes" type="text" class="mt-1 block w-full"/>
-            <x-form-validation for="notes" />
+            <x-input-label for="primary_sector_id" :value="__('Primary Sector')" />
+            <x-select-input name="primary_sector_id" id="primary_sector_id" class="block w-64 text-sm">
+                <option class="text-gray-400" value="">-None-</option>
+                @foreach($sectors as $sector)
+                    <option value="{{ $sector->id }}">{{ $sector->name }}</option>
+                @endforeach
+            </x-select-input>
+            <x-form-validation for="primary_sector_id" />
         </div>
+
+        <!-- Primary Department ID -->
+        <div>
+            <x-input-label for="password" :value="__('Primary Department')" />
+            <x-select-input name="primary_dept_id" id="primary_dept_id" class="block w-64 text-sm"> <!-- required> -->
+                <option value="">-None-</option>
+                @foreach($departments as $department)
+                    <option value="{{ $department->id }}">
+                        {{ $department->name }}
+                    </option>
+                @endforeach
+                <!-- Options will be populated by JavaScript based on the selected sector -->
+            </x-select-input>
+            <x-form-validation for="primary_dept_id" />
+        </div>
+
+
+        <hr>
 
         <!-- Password -->
         <div>
@@ -75,32 +107,7 @@
             <p>Use <a href="https://password.link/" style="color:blue">https://password.link/</a> to securely send passwords to users.</p>
         </div>
 
-        <!-- Primary Department ID -->
-        <div>
-            <x-input-label for="password" :value="__('Primary Department')" />
-            <x-select-input name="primary_dept_id" id="primary_dept_id" class="block w-64 text-sm"> <!-- required> -->
-                <option value="">-None-</option>
-                @foreach($departments as $department)
-                    <option value="{{ $department->id }}">
-                        {{ $department->name }}
-                    </option>
-                @endforeach
-                <!-- Options will be populated by JavaScript based on the selected sector -->
-            </x-select-input>
-            <x-form-validation for="primary_dept_id" />
-        </div>
-        
-        <!-- Primary Sector ID -->
-        <div>
-            <x-input-label for="primary_sector_id" :value="__('Primary Sector')" />
-            <x-select-input name="primary_sector_id" id="primary_sector_id" class="block w-64 text-sm">
-                <option class="text-gray-400" value="">-None-</option>
-                @foreach($sectors as $sector)
-                    <option value="{{ $sector->id }}">{{ $sector->name }}</option>
-                @endforeach
-            </x-select-input>
-            <x-form-validation for="primary_sector_id" />
-        </div>
+        <hr>
 
         <!-- Submit Button -->
         <div class="flex items-center gap-4">

--- a/resources/views/users/partials/create-user-form.blade.php
+++ b/resources/views/users/partials/create-user-form.blade.php
@@ -104,7 +104,9 @@
         </div>
 
         <div>
-            <p>Use <a href="https://password.link/" style="color:blue">https://password.link/</a> to securely send passwords to users.</p>
+            <p>Tip: Use <a href="https://password.link/" style="color:blue">https://password.link/</a> to securely send passwords to users.</p>
+            <br>
+            <b>Make sure to encourage new users to change their account password immediately after signing in!</b>
         </div>
 
         <hr>

--- a/resources/views/users/partials/create-user-form.blade.php
+++ b/resources/views/users/partials/create-user-form.blade.php
@@ -68,7 +68,7 @@
                 <x-required-asterisk/>
             </div>
             <x-text-input id="password_confirmation" type="password" placeholder="XXXXXXXX" name="password_confirmation" class="mt-1 block w-full" required />
-            <x-form-validation for="password_confirmation />
+            <x-form-validation for="password_confirmation" />
         </div>
 
         <!-- Primary Department ID -->

--- a/resources/views/users/partials/create-user-form.blade.php
+++ b/resources/views/users/partials/create-user-form.blade.php
@@ -6,7 +6,7 @@
 
         <!-- Name -->
         <div>
-            <div style="display: flex; direction: column">
+            <div class="flex flex-row">
                 <x-input-label for="name" :value="__('Name')" />
                 <x-required-asterisk/>
             </div>
@@ -16,7 +16,7 @@
 
         <!-- Email -->
         <div>
-            <div style="display: flex; direction: column">
+            <div class="flex flex-row">
                 <x-input-label for="email" :value="__('Email')" />
                 <x-required-asterisk/>
             </div>
@@ -85,7 +85,7 @@
 
         <!-- Password -->
         <div>
-            <div style="display: flex; direction: column">
+            <div class="flex flex-row">
                 <x-input-label for="password" :value="__('Password')" />
                 <x-required-asterisk/>
             </div>
@@ -95,8 +95,8 @@
 
         <!-- Confirm Password -->
         <div>
-            <div style="display: flex; direction: column">
-            <x-input-label for="password_confirmation" :value="__('Confirm Password')" />
+            <div class="flex flex-row">
+                <x-input-label for="password_confirmation" :value="__('Confirm Password')" />
                 <x-required-asterisk/>
             </div>
             <x-text-input id="password_confirmation" type="text" placeholder="XXXXXXXX" name="password_confirmation" class="mt-1 block w-full" required />
@@ -104,7 +104,7 @@
         </div>
 
         <div>
-            <p>Tip: Use <a href="https://password.link/" style="color:blue">https://password.link/</a> to securely send passwords to users.</p>
+            <p>Tip: Use <a href="https://password.link/" class="text-blue-500">https://password.link/</a> to securely send passwords to users.</p>
             <br>
             <b>Make sure to encourage new users to change their account password immediately after signing in!</b>
         </div>


### PR DESCRIPTION
Addresses #17 

Upon accessing the admin user creation page, the password fields are automatically filled with a cryptographically random 16-digit hexadecimal value.

This implementation relies on the user's browser being able to execute the standard JavaScript function `crypto.generateRandomValues()`, which according to [https://caniuse.com/getrandomvalues](https://caniuse.com/getrandomvalues), 96.44% of users' browsers can. In the event that the user's browser cannot execute this function, this case is explicitly handled, and the password fields are left blank (and will need to be manually filled).

Rico (and myself) notes that this solution, while adequate, is inferior to using email to set passwords for new users. Once the associated email server is set up, this code will be refactored.

![image](https://github.com/user-attachments/assets/34a9e96b-059b-4c62-a520-8bba8ade7b78)